### PR TITLE
Fix #6 links wrap into p

### DIFF
--- a/docs/about/index.html
+++ b/docs/about/index.html
@@ -9,7 +9,7 @@
   <!-- favicon though they are not working yet 09-17-2019 -->
   <link rel="shortcut icon" type="image/x-icon" href="favicon.ico"/>
   <link rel="icon" type="image/ico" href="favicon.ico"/>
-  
+
 </head>
 
   <body>
@@ -26,9 +26,9 @@
     <div id='content-area'>
       <section id="wayfinding" role="navigation"></section>
       <main id="primary-content" role="main">
-        
+
           <h1>About</h1>
-        
+
         <p>This site offers the prototype of our Variorum Viewer of the novel Frankenstein.
 We also provide some information about our approach and methods, as well as the various people who have worked on this projects since its beginnings in 2017.</p>
 
@@ -41,9 +41,9 @@ We also provide some information about our approach and methods, as well as the 
 <p>The following are distinct editions prepared “under the hood” by correcting prior digital editions and preparing new digital editions the 1823 and Thomas edition. These files represent each edition prior to collation processing. Comparison data is not marked in these documents, but each is a distinct edition in its own right suitable for reading and annotation.</p>
 
 <ol>
-  <li><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1818.html">1818 publication of Frankenstein</a>.
+  <li><p><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1818.html">1818 publication of Frankenstein</a>.</p>
     <ul>
-      <li><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1818_classEd.html">Pitt-Greensburg classroom edition of the 1818 text</a> (a copy of the same) for use in annotation assignments.</li>
+      <li><p><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1818_classEd.html">Pitt-Greensburg classroom edition of the 1818 text</a> (a copy of the same) for use in annotation assignments.</p></li>
     </ul>
   </li>
   <li>
@@ -52,7 +52,7 @@ We also provide some information about our approach and methods, as well as the 
   <li>
     <p><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1823.html">1823 publication of Frankenstein</a> (supervised by William Godwin).</p>
   </li>
-  <li><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1831.html">1831 publication of Frankenstein</a>.</li>
+  <li><p><a href="https://ebeshero.github.io/Pittsburgh_Frankenstein/Frankenstein_1831.html">1831 publication of Frankenstein</a>.</p></li>
 </ol>
 
       </main>


### PR DESCRIPTION
Fix #6 

Solution: links wrapped into `<p>` tags. Because underline style assigned only for `p a` in stylesheet.